### PR TITLE
Add `json` extension to networks import

### DIFF
--- a/network/index.js
+++ b/network/index.js
@@ -1,4 +1,4 @@
-const networks = require("./networks")
+const networks = require("./networks.json")
 
 class Network {
   constructor(name, version = "v1") {


### PR DESCRIPTION
As workaround for TypeScript compilers since they can't resolve JSON files without an extension.

See microsoft/TypeScript#24357