### PR TITLE
fix(ci): grant contents:write to AWS deploy workflow chain

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -16,7 +16,7 @@ on:
         description: 'JSON-encoded build-time secrets forwarded to the ECS deploy workflow.'
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -14,7 +14,7 @@ on:
           - prod
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Summary

Hotfix for [Static Deployment run 25907576431](https://github.com/0xPolygon/static/actions/runs/25907576431) which failed at startup on the merge of #183 (changesets-release for `@polygonlabs/meta@1.0.0`).

PR #182 hardened `deployment.yml` and `build_and_deploy.yml` with explicit top-level `permissions: { contents: read, id-token: write }` to replace the previous `secrets: inherit` / no-permissions defaults. That's not a superset of what the called shared workflow needs — `0xPolygon/pipelines/.github/workflows/ecs_deploy_docker_taskdef.yaml` declares `permissions: { id-token: write, contents: write }` on its `deploy_workflow` job — so GitHub Actions failed at workflow startup before any step ran.

Both calling workflows now declare `contents: write`. `id-token: write` is unchanged. The token is still scoped down to just the two scopes the AWS deploy actually uses — it's not a regression back to `inherit`-everything.

## Test plan

- [x] Workflow YAML is still valid (prettier clean).
- [ ] Merge this PR.
- [ ] Re-run the failed deployment (or push an empty commit to `master`) and verify `Static Deployment` reaches the `deploy` job and completes 1.0.0's ECS rollout.