### PR TITLE
fix(meta): lower engines.node floor to >=20 to match runtime

### DIFF
--- a/.changeset/meta-engines-node-20.md
+++ b/.changeset/meta-engines-node-20.md
@@ -1,0 +1,9 @@
+---
+"@polygonlabs/meta": patch
+---
+
+Lower the published `engines.node` floor from `>=24` to `>=20` to match the package's actual runtime requirements.
+
+`@polygonlabs/meta` ships only `as const` data modules — typed ABIs and network metadata — with zero runtime code; every module under `dist/generated/**` is a plain `export const ... = [...] as const` literal. It has no Node 24 runtime dependency. The previous `>=24` floor described the build toolchain (codegen runs `node scripts/codegen.ts` via Node's native TypeScript execution), not what consumers need to run the package, and surfaced a spurious engine-mismatch warning for anyone targeting Node 20.
+
+The build-time Node 24 requirement is now declared explicitly in `devEngines.runtime` and documented in CONTRIBUTING, leaving `engines.node` to describe the consumer runtime. Downstream SDKs that target Node 20 — such as `@polygonlabs/pos-sdk` — can now depend on `@polygonlabs/meta` without inheriting an inaccurate Node 24 floor.

--- a/packages/meta/CONTRIBUTING.md
+++ b/packages/meta/CONTRIBUTING.md
@@ -101,6 +101,22 @@ pnpm run build        # codegen + tsc → dist/
 `prepack` runs `build`, so `pnpm pack` and `pnpm publish` always emit
 a fresh dist.
 
+### Node version: build vs. runtime
+
+`codegen` runs the script directly with `node scripts/codegen.ts`,
+which relies on Node's native TypeScript execution — so **building**
+this package requires Node 24. That requirement is declared in
+`devEngines.runtime`.
+
+The **published** package, however, is pure data: every module under
+`dist/generated/**` is an `export const ... = [...] as const` literal
+with no runtime code, so it runs on any Node that supports ESM subpath
+exports. `engines.node` is therefore set to `>=20` to describe the
+consumer runtime, not the build toolchain. Don't raise it to match the
+build requirement — that would force a Node 24 floor on downstream SDKs
+(e.g. `@polygonlabs/pos-sdk`) that legitimately target Node 20 for no
+runtime reason.
+
 ## Release
 
 This repo uses [Changesets](https://github.com/changesets/changesets)

--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -49,7 +49,14 @@
   ],
   "packageManager": "pnpm@10.30.3",
   "engines": {
-    "node": ">=24"
+    "node": ">=20"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=24",
+      "onFail": "warn"
+    }
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
The published `@polygonlabs/meta` package is pure `as const` data — typed ABIs and network metadata. Every module under `dist/generated/**` is a plain `export const ... = [...] as const` literal with no runtime code, so it has no Node 24 runtime requirement.

The `engines.node: ">=24"` floor actually described the **build** toolchain: `codegen` runs `node scripts/codegen.ts` via Node's native TypeScript execution, which needs Node 24. But `engines` is consumer-facing — so installing the package on Node 20 surfaced a spurious engine-mismatch warning even though it runs fine.

## What this changes

- `engines.node` → `>=20`, describing the actual consumer runtime.
- The build-time Node 24 requirement moves to `devEngines.runtime` (`onFail: "warn"`), so it stays visible to contributors without leaking onto consumers.
- CONTRIBUTING gains a short "Node version: build vs. runtime" note explaining the split and warning against re-raising the floor.

The monorepo root `package.json` already declares `engines.node: ">=24"` for the dev/build environment, so the contributor floor is unchanged — this only corrects the *published* package's claim.

## Why now

`@polygonlabs/pos-sdk` (the matic.js 1.0 rewrite) wants to drop its hand-vendored ABIs and depend on `@polygonlabs/meta` as the single source of truth, but targets Node 20. The `>=24` floor would have forced an inaccurate Node 24 requirement onto every pos-sdk consumer for no runtime reason. The ABIs pos-sdk needs are byte-identical across networks and already `as const` here, so meta is a clean drop-in once the floor is accurate.

## Release

Patch changeset included (`@polygonlabs/meta`). Merging opens the Version Packages PR for a point release; no code or generated output changed, so this is a metadata-only bump.