### PR TITLE
chore(deploy): bind production to static.polygon.technology via custom_domain

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,17 +26,13 @@ command = "pnpm run build:cdn"
 [env.staging]
 routes = [{ pattern = "static-cf.polygon.technology", custom_domain = true }]
 
-# Apex — deliberately NO domain binding yet. static.polygon.technology still has an
-# externally-managed record pointing at AWS, so no wrangler-side binding can take it
-# over (see staging note). The zero-downtime cutover, per SPEC, ordered so that a
-# stray production deploy is harmless at every step:
-#   1. Merge this, dispatch production once — green run, the worker now exists
-#      (polygon-static-production).
-#   2. Immediately land the follow-up PR setting `routes = [{ pattern =
-#      "static.polygon.technology", custom_domain = true }]` here. Until the swap
-#      (step 3), any production dispatch fails harmlessly at the domain-registration
-#      step (code 100117) — wrangler deploys the script BEFORE registering domains,
-#      so nothing already deployed or bound is touched.
-#   3. SPEC swaps the existing DNS record onto the worker in the CF dashboard.
-#   4. Dispatch production to verify wrangler now owns the domain (idempotent).
+# Apex. The worker (polygon-static-production) is deployed and unbound; the
+# static.polygon.technology record still points at AWS (externally managed), so no
+# wrangler-side binding can take it over from CI (see staging note). Until SPEC
+# swaps the record onto the worker in the CF dashboard, a production deploy fails
+# harmlessly at the domain-registration step (code 100117) — the script deploys
+# before domain registration, so nothing already deployed or bound is touched.
+# After the swap, this config matches the dashboard state and deploys idempotently
+# own the domain.
 [env.production]
+routes = [{ pattern = "static.polygon.technology", custom_domain = true }]


### PR DESCRIPTION
## What

Lands the standard production binding:

```toml
routes = [{ pattern = "static.polygon.technology", custom_domain = true }]
```

The production Worker (`polygon-static-production`) is already deployed and unbound (#191, run [28955516442](https://github.com/0xPolygon/static/actions/runs/28955516442)).

## Why land this before the domain is attached

With `custom_domain` declared ahead of the cutover, a premature production dispatch fails harmlessly at the domain-registration step — the script deploys before domain registration, and nothing routes to this Worker yet. The reverse order would leave a window where a deploy with *no* domain declared could remove a freshly attached binding. This ordering makes a stray dispatch safe at every step.

Once the hostname is attached to the Worker, the landed config matches the live state and every subsequent deploy idempotently owns the domain.

No changeset — change is outside `packages/meta/`.
