### PR TITLE
fix(deploy): answer CORS preflight OPTIONS from a worker script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,10 @@ Two public surfaces driven from one source JSON tree at the repo-root
    the same JSON files served verbatim from Cloudflare Workers static
    assets. `scripts/assemble-cdn.sh` (`pnpm run build:cdn`) stages
    `network/`, `index.html`, and `public/_headers` into `dist/`, which
-   `wrangler.toml` serves directly (no worker script). CORS and caching
-   live in `public/_headers`.
+   `wrangler.toml` serves directly. `worker/worker.ts` answers CORS
+   preflight OPTIONS (the asset layer serves GET/HEAD only and 405s
+   everything else, which blocks maticjs in browsers); response CORS
+   and caching for asset hits live in `public/_headers`.
 
    `deploy.yml` is trunk-based: every push to `master` deploys
    **staging** (`static-cf.polygon.technology`, a `custom_domain` on a

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,6 @@ import { recommended, typescript } from '@polygonlabs/apps-team-lint';
 
 export default defineConfig([
   ...recommended({ globals: 'node' }),
-  ...typescript(),
+  ...typescript({ tsconfigRootDir: import.meta.dirname }),
   { ignores: ['.claude/**', '**/dist/**', 'packages/meta/src/generated/**'] }
 ]);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
+    "@cloudflare/workers-types": "^4.20260702.1",
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
     "@polygonlabs/apps-team-lint": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@24.12.2)
+      '@cloudflare/workers-types':
+        specifier: ^4.20260702.1
+        version: 4.20260702.1
       '@commitlint/cli':
         specifier: ^19.0.0
         version: 19.8.1(@types/node@24.12.2)(typescript@6.0.3)
@@ -55,7 +58,7 @@ importers:
         version: 3.8.3
       wrangler:
         specifier: ^4.78.0
-        version: 4.103.0
+        version: 4.103.0(@cloudflare/workers-types@4.20260702.1)
 
   packages/meta:
     devDependencies:
@@ -192,6 +195,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-types@4.20260702.1':
+    resolution: {integrity: sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==}
 
   '@commitlint/cli@19.8.1':
     resolution: {integrity: sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==}
@@ -2496,6 +2502,8 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260617.1':
     optional: true
 
+  '@cloudflare/workers-types@4.20260702.1': {}
+
   '@commitlint/cli@19.8.1(@types/node@24.12.2)(typescript@6.0.3)':
     dependencies:
       '@commitlint/format': 19.8.1
@@ -4513,7 +4521,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260617.1
       '@cloudflare/workerd-windows-64': 1.20260617.1
 
-  wrangler@4.103.0:
+  wrangler@4.103.0(@cloudflare/workers-types@4.20260702.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)
@@ -4524,6 +4532,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260617.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260702.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/public/_headers
+++ b/public/_headers
@@ -1,14 +1,17 @@
-# Cloudflare static-assets header rules.
+# Cloudflare static-assets header rules — applied to asset (GET/HEAD)
+# responses only. Preflight OPTIONS never reaches the asset layer; it is
+# answered by worker/worker.ts, which owns the Allow-Headers/Max-Age surface.
 #
-# This is a read-only public store, so the CORS surface reflects what it
-# actually does: cross-origin GETs of JSON. The previous nginx origin also
-# advertised POST and Authorization/Content-Type, but nothing here accepts a
-# write or reads credentials — that was cargo-cult and is dropped.
+# The nginx origin's Authorization/Content-Type allow-header was NOT
+# cargo-cult (an earlier revision dropped it as such): maticjs sends
+# Content-Type on its GETs, which makes browsers preflight, and the missing
+# preflight handling broke every browser consumer of the SDK. Allow-headers
+# only matter on the preflight response, so they live in the worker, not here.
 #
 # Cache-Control is new: the store is fetched uncached at every maticjs client
 # init, so a short shared-cache TTL cuts repeated edge/origin load without
 # risking staleness for the rare network/ABI additions.
 /*
   Access-Control-Allow-Origin: *
-  Access-Control-Allow-Methods: GET, OPTIONS
+  Access-Control-Allow-Methods: GET, HEAD, OPTIONS
   Cache-Control: public, max-age=300

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["esnext"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["worker.ts"]
+}

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -1,0 +1,35 @@
+// CORS preflight shim in front of the static-assets bundle.
+//
+// Cloudflare's asset layer serves GET/HEAD only; every other method routes to
+// the worker script — or returns 405 when none exists. That 405 broke maticjs
+// in every browser: it sends Content-Type on its GET of
+// /network/<network>/<version>/index.json, browsers therefore preflight with
+// OPTIONS, and a failed preflight blocks the GET entirely. This worker answers
+// OPTIONS and delegates everything else to the asset layer. run_worker_first
+// is required (see wrangler.toml): with default routing the asset layer 405s
+// OPTIONS on asset-matched paths itself and the worker never sees it.
+interface Env {
+  ASSETS: Fetcher;
+}
+
+export default {
+  async fetch(request, env): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+          // Content-Type is what maticjs sends (see above); Authorization
+          // restores the old nginx origin's allowance for clients that
+          // attach it.
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+          'Access-Control-Max-Age': '86400'
+        }
+      });
+    }
+    // Everything else defers to the asset layer, which applies _headers and
+    // not_found_handling as if the worker weren't here.
+    return env.ASSETS.fetch(request);
+  }
+} satisfies ExportedHandler<Env>;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,9 +1,13 @@
 # Cloudflare Workers static-assets deployment for the static.polygon.technology
-# HTTP endpoint. No worker script — Cloudflare serves the assembled dist/ bundle
-# (network/ JSON tree + health-check index.html + _headers) directly from its
-# edge. Replaces the previous nginx-on-ECS origin; the npm package
-# (@polygonlabs/meta, packages/meta/) is a separate surface and unaffected.
+# HTTP endpoint. Cloudflare serves the assembled dist/ bundle (network/ JSON
+# tree + health-check index.html + _headers) directly from its edge; the tiny
+# worker script exists only because the asset layer serves GET/HEAD and 405s
+# every other method — including the OPTIONS preflights browsers send for
+# maticjs's Content-Type-bearing GETs (see worker/worker.ts). Replaces the
+# previous nginx-on-ECS origin; the npm package (@polygonlabs/meta,
+# packages/meta/) is a separate surface and unaffected.
 name = "polygon-static"
+main = "worker/worker.ts"
 compatibility_date = "2026-06-24"
 placement = { mode = "smart" }
 workers_dev = false
@@ -15,6 +19,14 @@ directory = "./dist"
 # Missing paths return a real 404 (a JSON CDN, not an SPA). The old nginx
 # try_files fell back to index.html, masking 404s as 200+HTML.
 not_found_handling = "none"
+# Lets the worker delegate non-OPTIONS requests back to the asset layer.
+binding = "ASSETS"
+# Required for the worker to see OPTIONS at all: without it the asset layer
+# answers non-GET/HEAD on asset-matched paths itself (405) — verified with
+# `wrangler dev`; the docs' "other methods route to the Worker" doesn't hold
+# for matched paths. GET/HEAD delegated via the binding still get _headers
+# and not_found_handling applied.
+run_worker_first = true
 
 [build]
 command = "pnpm run build:cdn"


### PR DESCRIPTION
## Problem

The static-assets layer serves GET/HEAD only and returns **405** to every other method — including the preflight `OPTIONS` browsers send before a GET that carries a `Content-Type` header. maticjs sends that header when fetching `/network/<network>/<version>/index.json`, so the failed preflight blocks the request and client initialisation fails in every browser. The previous nginx origin answered `OPTIONS` with 204 and allowed `Content-Type`/`Authorization`.

## Fix

A minimal worker entry (`worker/worker.ts`) answers `OPTIONS` with `204` and the CORS preflight headers, and delegates everything else to the assets binding — `_headers` and `not_found_handling` still apply, so GET behaviour is unchanged.

`run_worker_first = true` is required: with default routing the asset layer answers `OPTIONS` on asset-matched paths itself (405) before the worker runs (verified with `wrangler dev`).

Supporting changes: `main` + `ASSETS` binding in `wrangler.toml`, `worker/tsconfig.json` plus the `@cloudflare/workers-types` devDep, `tsconfigRootDir` in `eslint.config.js` (the repo now has two tsconfig roots), and doc touch-ups.

## Verification (local `wrangler dev`)

| Request | Result |
| --- | --- |
| `OPTIONS /network/mainnet/v1/index.json` (`Access-Control-Request-Headers: content-type`) | `204` + full preflight header set |
| `GET /network/mainnet/v1/index.json` | `200`, `_headers` CORS + `Cache-Control` intact |
| `GET /` | `200` |
| `GET /network/nope/v1/index.json` | `404` |

## Deploy notes

Merge auto-deploys staging; production is a manual `workflow_dispatch` of `deploy.yml`.

https://claude.ai/code/session_019bL7UgsRRhAC15kxdH3q2y